### PR TITLE
Changed error handling of responses

### DIFF
--- a/src/utils/responseHandlers.ts
+++ b/src/utils/responseHandlers.ts
@@ -12,7 +12,7 @@ class ResponseHandler {
       })
       .catch((error: any) => {
         if (error.response) {
-          return Promise.reject(error.resonse);
+          return Promise.reject(error.response);
         }
         return Promise.reject(new Error(error.message));
       });

--- a/src/utils/responseHandlers.ts
+++ b/src/utils/responseHandlers.ts
@@ -3,51 +3,58 @@ import { ApiResponse } from './apiResponse';
 
 class ResponseHandler {
   toApiResponse(promise: Promise<any>) {
-    return promise.then((response) => {
-      if (!response) {
-        return Promise.reject(new Error('Request failed.'));
-      }
-      if (response.status === 200 && response.data.Success) {
-        return response.data;
-      }
-      // response.statusText is never null,
-      // rather an empty string is returned on eg. 403 => fallback to status code
-      const message = response.statusText || response.status.toString();
-      return Promise.reject(new Error(message));
-    });
+    return promise
+      .then((response: AxiosResponse) => {
+        if (response.data.Success) {
+          return response.data;
+        }
+        return Promise.reject(response);
+      })
+      .catch((error: any) => {
+        if (error.response) {
+          return Promise.reject(error.resonse);
+        }
+        return Promise.reject(new Error(error.message));
+      });
   }
 
   /**
    * @return A promise that resolves to T or rejects if no results
    */
   required<T>(promise: Promise<AxiosResponse>): Promise<T> {
-    return this.toApiResponse(promise).then((response: ApiResponse<T[]>) => {
-      if (response.NumResults > 0) {
-        return response.Results[0];
-      }
-      return Promise.reject(new Error(response.ErrorMessage!));
-    });
+    return this.toApiResponse(promise)
+      .then((response: ApiResponse<T[]>) => {
+        if (response.NumResults > 0) {
+          return response.Results[0];
+        }
+        return Promise.reject(new Error(response.ErrorMessage!));
+      })
+      .catch((error) => error);
   }
 
   requiredList<T>(promise: Promise<AxiosResponse>): Promise<T[]> {
-    return this.toApiResponse(promise).then((response: ApiResponse<T[]>) => {
-      if (response.NumResults > 0) {
-        return response.Results;
-      }
-      return Promise.reject(new Error(response.ErrorMessage != null ? response.ErrorMessage : 'No results'));
-    });
+    return this.toApiResponse(promise)
+      .then((response: ApiResponse<T[]>) => {
+        if (response.NumResults >= 0) {
+          return response.Results;
+        }
+        return Promise.reject(new Error(response.ErrorMessage != null ? response.ErrorMessage : 'No results'));
+      })
+      .catch((error) => error);
   }
 
   /**
    * @return A promise that resolves to T or null if no results but Success is true.
    */
   optional<T>(promise: Promise<AxiosResponse>): Promise<T | undefined> {
-    return this.toApiResponse(promise).then((response: ApiResponse<T[]>) => {
-      if (response.Success) {
-        return (response.NumResults > 0 && response.Results[0]) || undefined;
-      }
-      return Promise.reject(response.ErrorMessage);
-    });
+    return this.toApiResponse(promise)
+      .then((response: ApiResponse<T[]>) => {
+        if (response.Success) {
+          return (response.NumResults > 0 && response.Results[0]) || undefined;
+        }
+        return Promise.reject(response.ErrorMessage);
+      })
+      .catch((error) => error);
   }
 }
 


### PR DESCRIPTION
* Empty request doesn't throw an error
* If a request fails with and not valid status code,  the response is returned
* if a request fails for some other reason, the error message is returned.