### PR TITLE
Fix AbsenceDay endpoint and type

### DIFF
--- a/src/absenceDays/index.ts
+++ b/src/absenceDays/index.ts
@@ -4,7 +4,7 @@ import RequestParams from '../utils/requestParams/requestParams';
 import { AbsenceDay } from './types';
 
 export default class AbsenceDays extends BaseApi {
-  public readonly resourceName = 'absencesDays';
+  public readonly resourceName = 'absenceDays';
 
   public read(requestParams?: RequestParams<AbsenceDay> | Object): Promise<AbsenceDay[]> {
     const params = requestParams instanceof RequestParams ? requestParams.getParams() : requestParams;

--- a/src/absenceDays/types.ts
+++ b/src/absenceDays/types.ts
@@ -5,12 +5,13 @@ export type AbsenceDay = {
   user_role_id: number;
   date: string;
   type: string;
-  other_paid_leave_id: number;
   value: number;
   value_unit: string;
   request_id: number;
   status: number;
   comment: string;
   begin: string;
-  updated: string;
+  updated: string | null;
+  type_id: number;
+  subtype_id: number;
 };


### PR DESCRIPTION
- `updated` can be null (and mostly seems to be null in the DB)
- `other_paid_leave_id` is aliased to (and returned as) `subtype_id` by the backend
- `type_id` was missing