### PR TITLE
Remove last_started as field is not used

### DIFF
--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -30,7 +30,6 @@ export type Task = {
   duration?: number;
   is_startable?: boolean;
   is_paid_non_working?: boolean;
-  last_started?: string;
 };
 
 export interface TaskCreate extends Omit<Task, 'id' | 'node_path' | 'view_id'> {}


### PR DESCRIPTION
- field is not used
- presence of field leads to type mismatch which no sense to fix now