### PR TITLE
Check that response.data is not a string before using `in`

### DIFF
--- a/src/utils/axiosSetup.test.ts
+++ b/src/utils/axiosSetup.test.ts
@@ -35,7 +35,7 @@ const mockInterceptorParams: InterceptorParams = {
 
 describe('axiosSetup', () => {
   test('interceptor calls onTokenRefreshFailed', async (done) => {
-    const mockErrorUnauthenticated: AxiosError = {
+    const mockErrorUnauthenticated: AxiosError = ({
       code: '401',
       response: {
         status: 401,
@@ -51,7 +51,7 @@ describe('axiosSetup', () => {
       isAxiosError: true,
       message: 'unauthorized',
       name: 'the name',
-    } as unknown as AxiosError;
+    } as unknown) as AxiosError;
 
     const mockErrorRefreshFailed: AxiosError = {
       config: {},
@@ -88,9 +88,9 @@ describe('axiosSetup', () => {
   });
 
   test('interceptor throws error without status code', async (done) => {
-    const mockErrorUnauthenticated: AxiosError = {
+    const mockErrorUnauthenticated: AxiosError = ({
       message: 'Request failed with status code 504',
-    } as unknown as AxiosError;
+    } as unknown) as AxiosError;
 
     const interceptor = createResponseRejectedInterceptor(mockInterceptorParams);
 
@@ -103,10 +103,10 @@ describe('axiosSetup', () => {
     done();
   });
   test('interceptor gets error with status code typed as string', async (done) => {
-    const mockErrorUnauthenticated: AxiosError = {
+    const mockErrorUnauthenticated: AxiosError = ({
       code: '500',
       message: 'Request failed with status code 500',
-    } as unknown as AxiosError;
+    } as unknown) as AxiosError;
 
     const interceptor = createResponseRejectedInterceptor(mockInterceptorParams);
 

--- a/src/utils/axiosSetup.test.ts
+++ b/src/utils/axiosSetup.test.ts
@@ -35,7 +35,7 @@ const mockInterceptorParams: InterceptorParams = {
 
 describe('axiosSetup', () => {
   test('interceptor calls onTokenRefreshFailed', async (done) => {
-    const mockErrorUnauthenticated: AxiosError = ({
+    const mockErrorUnauthenticated: AxiosError = {
       code: '401',
       response: {
         status: 401,
@@ -51,7 +51,7 @@ describe('axiosSetup', () => {
       isAxiosError: true,
       message: 'unauthorized',
       name: 'the name',
-    } as unknown) as AxiosError;
+    } as unknown as AxiosError;
 
     const mockErrorRefreshFailed: AxiosError = {
       config: {},
@@ -88,9 +88,9 @@ describe('axiosSetup', () => {
   });
 
   test('interceptor throws error without status code', async (done) => {
-    const mockErrorUnauthenticated: AxiosError = ({
+    const mockErrorUnauthenticated: AxiosError = {
       message: 'Request failed with status code 504',
-    } as unknown) as AxiosError;
+    } as unknown as AxiosError;
 
     const interceptor = createResponseRejectedInterceptor(mockInterceptorParams);
 
@@ -103,10 +103,10 @@ describe('axiosSetup', () => {
     done();
   });
   test('interceptor gets error with status code typed as string', async (done) => {
-    const mockErrorUnauthenticated: AxiosError = ({
+    const mockErrorUnauthenticated: AxiosError = {
       code: '500',
       message: 'Request failed with status code 500',
-    } as unknown) as AxiosError;
+    } as unknown as AxiosError;
 
     const interceptor = createResponseRejectedInterceptor(mockInterceptorParams);
 

--- a/src/utils/response/rawApiResponse.ts
+++ b/src/utils/response/rawApiResponse.ts
@@ -24,6 +24,7 @@ export type RawApiResponse = {
 };
 
 function isRawApiResponse(response: Record<string, unknown>): response is RawApiResponse {
+  if (typeof response.data === 'string') return false;
   const hasHost = 'Host' in response;
   const hasCodeversion = 'Codeversion' in response;
   const hasSuccess = 'Success' in response;
@@ -42,7 +43,7 @@ export async function createRawApiResponse(promise: Promise<AxiosResponse>): Pro
     axiosResponse = await promise;
   } catch (e) {
     const error = e as AxiosError;
-    if (error.response?.data != null && 'Success' in error.response.data) {
+    if (error.response?.data != null && typeof error.response.data !== 'string' && 'Success' in error.response.data) {
       axiosResponse = error.response;
     } else {
       throw {

--- a/src/utils/response/responseHandlers.ts
+++ b/src/utils/response/responseHandlers.ts
@@ -14,7 +14,7 @@ export async function toApiResponse<T>(promise: RequestPromise<T>): Promise<ApiR
   } catch (e) {
     const error = e as AxiosError;
 
-    if (error.response?.data != null && 'Success' in error.response.data) {
+    if (error.response?.data != null && typeof error.response.data !== 'string' && 'Success' in error.response.data) {
       resolved = error.response;
     } else {
       throw {

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,14 +713,6 @@
     "@typescript-eslint/typescript-estree" "4.27.0"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.26.1.tgz#075a74a15ff33ee3a7ed33e5fce16ee86689f662"
-  integrity sha512-TW1X2p62FQ8Rlne+WEShyd7ac2LA6o27S9i131W4NwDSfyeVlQWhw8ylldNNS8JG6oJB9Ha9Xyc+IUcqipvheQ==
-  dependencies:
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/visitor-keys" "4.26.1"
-
 "@typescript-eslint/scope-manager@4.27.0":
   version "4.27.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.27.0.tgz#b0b1de2b35aaf7f532e89c8e81d0fa298cae327d"
@@ -729,28 +721,10 @@
     "@typescript-eslint/types" "4.27.0"
     "@typescript-eslint/visitor-keys" "4.27.0"
 
-"@typescript-eslint/types@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.26.1.tgz#9e7c523f73c34b04a765e4167ca5650436ef1d38"
-  integrity sha512-STyMPxR3cS+LaNvS8yK15rb8Y0iL0tFXq0uyl6gY45glyI7w0CsyqyEXl/Fa0JlQy+pVANeK3sbwPneCbWE7yg==
-
 "@typescript-eslint/types@4.27.0":
   version "4.27.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.27.0.tgz#712b408519ed699baff69086bc59cd2fc13df8d8"
   integrity sha512-I4ps3SCPFCKclRcvnsVA/7sWzh7naaM/b4pBO2hVxnM3wrU51Lveybdw5WoIktU/V4KfXrTt94V9b065b/0+wA==
-
-"@typescript-eslint/typescript-estree@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.1.tgz#b2ce2e789233d62283fae2c16baabd4f1dbc9633"
-  integrity sha512-l3ZXob+h0NQzz80lBGaykdScYaiEbFqznEs99uwzm8fPHhDjwaBFfQkjUC/slw6Sm7npFL8qrGEAMxcfBsBJUg==
-  dependencies:
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/visitor-keys" "4.26.1"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.27.0":
   version "4.27.0"
@@ -764,14 +738,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.1.tgz#0d55ea735cb0d8903b198017d6d4f518fdaac546"
-  integrity sha512-IGouNSSd+6x/fHtYRyLOM6/C+QxMDzWlDtN41ea+flWuSF9g02iqcIlX8wM53JkfljoIjP0U+yp7SiTS1onEkw==
-  dependencies:
-    "@typescript-eslint/types" "4.26.1"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.27.0":
   version "4.27.0"


### PR DESCRIPTION
In a few places we use `in` operator, however sometimes the backend returns non-json response which cannot be parsed (I think I got an html 404 page "naturally" at some point) and these checks fail with `Cannot search for "Success" in "response string goes here"`.

Also, there are some formatting changes in one of the tests, because the precommit hook insisted that I need to run prettier.

UPD: Apparently, my local prettier's output didn't match the one on CI. Had to `yarn install` to take care of it, but it also changed the lockfile. But seems like the test formatting changes are gone now :man_shrugging: 