### PR TITLE
Upgrade CI image required node version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install and publish
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn publish


### PR DESCRIPTION
- upgrade CI image node version because current one has v. 12 and one of libraries needs > v.14 
https://github.com/TimeTac/js-client-library/runs/6454372681?check_suite_focus=true 