### PR TITLE
call onTokenRefreshFailed on 503 error

### DIFF
--- a/src/utils/axiosSetup.ts
+++ b/src/utils/axiosSetup.ts
@@ -60,7 +60,7 @@ export const createResponseRejectedInterceptor = (interceptorParams: Interceptor
         const error = e as AxiosError;
         // Check if refresh token expired, call tokenRefreshFailed() and then re-throw error
         const status = error.response?.status;
-        if (status === 497 || status === 404) {
+        if (status === 497 || status === 503) {
           if (interceptorParams.config.settings.onTokenRefreshFailed != null) {
             interceptorParams.config.settings.onTokenRefreshFailed();
           }

--- a/src/utils/axiosSetup.ts
+++ b/src/utils/axiosSetup.ts
@@ -60,7 +60,7 @@ export const createResponseRejectedInterceptor = (interceptorParams: Interceptor
         const error = e as AxiosError;
         // Check if refresh token expired, call tokenRefreshFailed() and then re-throw error
         const status = error.response?.status;
-        if (status === 497) {
+        if (status === 497 || status === 404) {
           if (interceptorParams.config.settings.onTokenRefreshFailed != null) {
             interceptorParams.config.settings.onTokenRefreshFailed();
           }

--- a/src/utils/axiosSetup.ts
+++ b/src/utils/axiosSetup.ts
@@ -60,7 +60,7 @@ export const createResponseRejectedInterceptor = (interceptorParams: Interceptor
         const error = e as AxiosError;
         // Check if refresh token expired, call tokenRefreshFailed() and then re-throw error
         const status = error.response?.status;
-        if (status === 497 || status === 503) {
+        if (status === 497 || status === 404 || status === 503) {
           if (interceptorParams.config.settings.onTokenRefreshFailed != null) {
             interceptorParams.config.settings.onTokenRefreshFailed();
           }


### PR DESCRIPTION
We should call `onTokenRefreshFailed` on 503 also, as it could be important to log user out then