### PR TITLE
Expand/tweak monitoring rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,13 @@ export { WorkScheduleDay, WorkScheduleDayUpdate } from './workScheduleDays/types
 export { WorkSchedule, WorkScheduleCreate, WorkScheduleUpdate } from './workSchedules/types';
 export { Tier } from './tiers/types';
 export { Feature } from './features/types';
-export { MonitoringRulesFrequency, MonitoringRulesRead, MonitotingRulesUpdate } from './monitoringRule/monitoringRules/types';
+export {
+  MonitoringRulesFrequency,
+  MonitoringRulesRead,
+  MonitoringRulesUpdate,
+  MonitoringRulesCreate,
+  MonitoringRuleNotificationOption,
+} from './monitoringRule/monitoringRules/types';
 export { MonitoringRuleTemplatesRead } from './monitoringRule/monitoringRuleTemplates/types';
 export { MonitoringRuleRecipientsRead } from './monitoringRule/monitoringRuleRecipients/types';
 export { MonitoringRuleIntervalsRead } from './monitoringRule/monitoringRuleIntervals/types';

--- a/src/monitoringRule/monitoringRules/index.ts
+++ b/src/monitoringRule/monitoringRules/index.ts
@@ -1,8 +1,8 @@
 import BaseApi from '../../baseApi';
 import { RequestParams } from '../../utils/params/requestParams';
 import { Entity, LibraryReturn } from '../../utils/response/apiResponse';
-import { list, required } from '../../utils/response/responseHandlers';
-import { MonitotingRulesUpdate } from './types';
+import { list, required, requiredSingle } from '../../utils/response/responseHandlers';
+import { MonitoringRulesCreate, MonitoringRulesUpdate } from './types';
 
 const resourceName = 'monitoringRules';
 type ResourceName = typeof resourceName;
@@ -17,8 +17,13 @@ export class MonitoringRulesEndpoint extends BaseApi<ResourceName> {
     return list(response);
   }
 
-  public update(data: MonitotingRulesUpdate, params?: RequestParams<Entity<ResourceName>>) {
+  public update(data: MonitoringRulesUpdate, params?: RequestParams<Entity<ResourceName>>) {
     const response = this._put<ResourceName>('update', data, params);
     return required(response);
+  }
+
+  public create(data: MonitoringRulesCreate, params?: RequestParams<Entity<ResourceName>>) {
+    const response = this._post<typeof resourceName>('create', data, params);
+    return requiredSingle(response);
   }
 }

--- a/src/monitoringRule/monitoringRules/types.ts
+++ b/src/monitoringRule/monitoringRules/types.ts
@@ -1,15 +1,25 @@
 export enum MonitoringRulesFrequency {
   Day = 'DAY',
+  Hour = 'HOUR',
   Week = 'WEEK',
   Month = 'MONTH',
   Year = 'YEAR',
   Minute = 'MINUTE',
 }
 
+export enum MonitoringRuleNotificationOption {
+  Notification = 'N',
+  Mail = 'M',
+  NotificationAndMail = 'NM',
+  Csv = 'C',
+  CsvAndMail = 'CM',
+  CsvAndNotificationAndMail = 'CNM',
+}
+
 export type MonitoringRulesRead = {
   id: number;
   default_template_id: string | null;
-  active: boolean;
+  active: number;
   title: string;
   description: string;
   handler_class?: string;
@@ -17,13 +27,43 @@ export type MonitoringRulesRead = {
   cron_freq: MonitoringRulesFrequency;
   cron_time: string;
   cron_last_run: string;
-  notification_channels: string;
+  notification_channels: MonitoringRuleNotificationOption;
   spam_protection_unit: string;
   config: string;
   updated_at: string;
 };
 
-export type MonitotingRulesUpdate = {
-  id: number;
-  active: boolean;
-};
+export type MonitoringRulesCreate = Required<
+  Pick<
+    MonitoringRulesRead,
+    | 'default_template_id'
+    | 'active'
+    | 'title'
+    | 'description'
+    | 'cron_freq_interval'
+    | 'cron_freq'
+    | 'cron_time'
+    | 'cron_last_run'
+    | 'notification_channels'
+  >
+> &
+  Partial<Pick<MonitoringRulesRead, 'id' | 'handler_class' | 'spam_protection_unit' | 'config'>>;
+
+export type MonitoringRulesUpdate = Required<Pick<MonitoringRulesRead, 'id'>> &
+  Partial<
+    Pick<
+      MonitoringRulesRead,
+      | 'default_template_id'
+      | 'active'
+      | 'title'
+      | 'description'
+      | 'handler_class'
+      | 'cron_freq'
+      | 'cron_freq_interval'
+      | 'cron_time'
+      | 'cron_last_run'
+      | 'notification_channels'
+      | 'spam_protection_unit'
+      | 'config'
+    >
+  >;


### PR DESCRIPTION
- tweak the types of some fields to match backend
- add definition for `create` payload
- add more field to the definition of `update` payload