### PR TITLE
Add new work schedule fields

### DIFF
--- a/src/workSchedules/types.ts
+++ b/src/workSchedules/types.ts
@@ -13,6 +13,9 @@ export type WorkSchedule = {
   type?: string;
   is_default?: boolean;
   absence_credit?: number;
+  automatic_break_template_id?: number | null;
+  rounding_times_template_id?: number | null;
+  public_holiday_template_id?: number | null;
 };
 
 export type WorkScheduleCreate = Omit<


### PR DESCRIPTION
Backend added 3 new fields to work schedules:
- automatic_break_template_id
- rounding_times_template_id
- public_holiday_template_id

Have the type set to `| null`, so that we can (try) to reset it back to nothing on update