### PR TITLE
Bump package version to 2.85.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@timetac/js-client-library",
-  "version": "2.85.0",
+  "version": "2.85.1",
   "description": "TimeTac API JS client library",
   "homepage": "https://github.com/TimeTac/js-client-library#readme",
   "repository": {


### PR DESCRIPTION
Publishes: 
- https://github.com/TimeTac/js-client-library/pull/903